### PR TITLE
Added missing model name in list view when there are no results. 

### DIFF
--- a/wagtailmodeladmin/templates/wagtailmodeladmin/index.html
+++ b/wagtailmodeladmin/templates/wagtailmodeladmin/index.html
@@ -53,12 +53,12 @@
             {% if not all_count %}
                 <div class="nice-padding" style="margin-top:30px;">
                     {% if no_valid_parents %}
-                        <p>{% blocktrans with module_name_plural as name %}No {{ name }} have been created yet. One of the following must be added to your site before any {{ name }} can be added.{% endblocktrans %}</p>
+                        <p>{% blocktrans with model_name_plural|lower as name %}No {{ name }} have been created yet. One of the following must be added to your site before any {{ name }} can be added.{% endblocktrans %}</p>
                         <ul>
                             {% for type in required_parent_types %}<li><b>{{ type|title }}</b></li>{% endfor %}
                         </ul>
                     {% else %}
-                        <p>{% blocktrans with module_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
+                        <p>{% blocktrans with model_name_plural|lower as name %}No {{ name }} have been created yet.{% endblocktrans %}
                         {% if has_add_permission %}
                             {% blocktrans with view.get_create_url as url %}
                                 Why not <a href="{{ url }}">add one</a>? 

--- a/wagtailmodeladmin/views.py
+++ b/wagtailmodeladmin/views.py
@@ -634,6 +634,7 @@ class IndexView(WMABaseView):
             'page_obj': page_obj,
             'object_list': page_obj.object_list,
             'has_add_permission': has_add_permission,
+            'model_name_plural': self.model_name_plural,
         }
 
         if self.is_pagemodel:


### PR DESCRIPTION
Currently it says 'No have been created yet.'  This patch fixes that so it includes the pluralised name of the model.
