### PR TITLE
Layout fix of choose parent page

### DIFF
--- a/wagtailmodeladmin/forms.py
+++ b/wagtailmodeladmin/forms.py
@@ -1,14 +1,14 @@
 from django import forms
 from django.utils.translation import ugettext as _
 from wagtail.wagtailcore.models import Page
-
+from django.utils.safestring import mark_safe
 
 class CustomModelChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
         bits = []
         for ancestor in obj.get_ancestors(inclusive=True).exclude(depth=1):
             bits.append(ancestor.title)
-        return ' > '.join(bits)
+        return mark_safe('<span class="icon icon-arrow-right"></span>'.join(bits))
 
 
 class ParentChooserForm(forms.Form):

--- a/wagtailmodeladmin/static/wagtailmodeladmin/css/choose_parent_page.css
+++ b/wagtailmodeladmin/static/wagtailmodeladmin/css/choose_parent_page.css
@@ -1,3 +1,6 @@
 form ul#id_parent_page li {
 	margin: 15px 0;
 }
+form ul#id_parent_page li label {
+  float: none;
+}


### PR DESCRIPTION
Placed radiobuttons below each other instead of next to each other,
Changed &gt; to Wagtail's arrow-right icon.

![before-after](https://cloud.githubusercontent.com/assets/1274867/11897522/a8925e76-a590-11e5-946f-2b590c987fcc.jpg)
