### PR TITLE
Removed unnecessary if statement in PermissionHelper.allow_list_view

### DIFF
--- a/wagtailmodeladmin/helpers.py
+++ b/wagtailmodeladmin/helpers.py
@@ -79,13 +79,11 @@ class PermissionHelper(object):
         For typical models, we only want to allow viewing of the list page
         if the user has permission to do something
         """
-        if (
+        return (
             self.has_add_permission(user) or
             self.has_edit_permission(user) or
             self.has_delete_permission(user)
-        ):
-            return True
-        return False
+        )
 
 
 class PagePermissionHelper(PermissionHelper):


### PR DESCRIPTION
Another small change I missed off my previous PR. Perhaps use of `any()` would be more descriptive but the following performance analysis has put me off that approach.

``` python
def a():
     return False or False or True

def b():
    if False or False or True:
        return True
    else:
        return False

def c():
    return any((
        False,
        False,
        True
    ))

>>> timeit.timeit('a()', 'from __main__ import a')                                                                                                                                      
0.17217302322387695
>>> timeit.timeit('b()', 'from __main__ import b')                                                                                                                                                   
0.19424986839294434
>>> timeit.timeit('c()', 'from __main__ import c')                                                                                                                                                   
0.28255510330200195
```
