### PR TITLE
Ability to add items into the Wagtail Settings sub-menu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ this:
         search_fields = ('title',)
         
     # Now you just need to register your customised ModelAdmin class with Wagtail
+    # Optionally pass True as a second parameter to add your model into Wagtail's Settings menu
     wagtailmodeladmin_register(MyPageModelAdmin)
 
 The Wagtail CMS menu would look something like this:

--- a/README.rst
+++ b/README.rst
@@ -107,12 +107,12 @@ this:
         menu_label = 'Page Model' # ditch this to use verbose_name_plural from model
         menu_icon = 'date' # change as required
         menu_order = 200 # will put in 3rd place (000 being 1st, 100 2nd)
+        add_to_settings_menu = False # or True to add your model to the Settings sub-menu
         list_display = ('title', 'example_field2', 'example_field3', 'live')
         list_filter = ('live', 'example_field2', 'example_field3')
         search_fields = ('title',)
         
     # Now you just need to register your customised ModelAdmin class with Wagtail
-    # Optionally pass True as a second parameter to add your model into Wagtail's Settings menu
     wagtailmodeladmin_register(MyPageModelAdmin)
 
 The Wagtail CMS menu would look something like this:

--- a/wagtailmodeladmin/options.py
+++ b/wagtailmodeladmin/options.py
@@ -22,7 +22,9 @@ class WagtailRegisterable(object):
     Base class, providing a more convenient way for ModelAdmin or
     ModelAdminGroup instances to be registered with Wagtail's admin area.
     """
-    def register_with_wagtail(self, register_in_settings=False):
+    add_to_settings_menu = False
+
+    def register_with_wagtail(self):
 
         @hooks.register('register_permissions')
         def register_permissions():
@@ -33,7 +35,7 @@ class WagtailRegisterable(object):
             return self.get_admin_urls_for_registration()
 
         menu_hook = (
-            'register_settings_menu_item' if register_in_settings else
+            'register_settings_menu_item' if self.add_to_settings_menu else
             'register_admin_menu_item'
         )
 
@@ -516,10 +518,10 @@ class AppModelAdmin(ModelAdminGroup):
         super(AppModelAdmin, self).__init__()
 
 
-def wagtailmodeladmin_register(wagtailmodeladmin_class, register_in_settings=False):
+def wagtailmodeladmin_register(wagtailmodeladmin_class):
     """
     Alternative one-line method for registering ModelAdmin or ModelAdminGroup
     classes with Wagtail.
     """
     instance = wagtailmodeladmin_class()
-    instance.register_with_wagtail(register_in_settings)
+    instance.register_with_wagtail()

--- a/wagtailmodeladmin/options.py
+++ b/wagtailmodeladmin/options.py
@@ -22,8 +22,7 @@ class WagtailRegisterable(object):
     Base class, providing a more convenient way for ModelAdmin or
     ModelAdminGroup instances to be registered with Wagtail's admin area.
     """
-
-    def register_with_wagtail(self):
+    def register_with_wagtail(self, register_in_settings=False):
 
         @hooks.register('register_permissions')
         def register_permissions():
@@ -33,7 +32,12 @@ class WagtailRegisterable(object):
         def register_admin_urls():
             return self.get_admin_urls_for_registration()
 
-        @hooks.register('register_admin_menu_item')
+        menu_hook = (
+            'register_settings_menu_item' if register_in_settings else
+            'register_admin_menu_item'
+        )
+
+        @hooks.register(menu_hook)
         def register_admin_menu_item():
             return self.get_menu_item()
 
@@ -512,10 +516,10 @@ class AppModelAdmin(ModelAdminGroup):
         super(AppModelAdmin, self).__init__()
 
 
-def wagtailmodeladmin_register(wagtailmodeladmin_class):
+def wagtailmodeladmin_register(wagtailmodeladmin_class, register_in_settings=False):
     """
     Alternative one-line method for registering ModelAdmin or ModelAdminGroup
     classes with Wagtail.
     """
     instance = wagtailmodeladmin_class()
-    instance.register_with_wagtail()
+    instance.register_with_wagtail(register_in_settings)


### PR DESCRIPTION
A little feature I needed that others might find useful.

This adds an optional new parameter (so shouldn't break any existing code) to `wagtailmodeladmin_register`, to have your model added into the Wagtail Settings sub-menu rather than the main menu.  The `register_settings_menu_item` hook it relies on was new in Wagtail 0.7.

Technically this does also work with ModelAdminGroups, but the Wagtail Settings menu has a fixed width, so the expanded group menu isn't visible unless you scroll horizontally to find it.
